### PR TITLE
Include tests in source distributions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ description = "Extends Hypothesis to add fully automatic testing of type annotat
 authors = ["Timothy Crosley <timothy.crosley@gmail.com>"]
 license = "MIT"
 readme = "README.md"
+include = [
+    { path = "tests", format = "sdist" },
+]
 
 [tool.poetry.dependencies]
 python = "^3.6"


### PR DESCRIPTION
Hi,
We at Gentoo (and Debian too AFAIK) tend to use PyPI tarballs to run tests. Could you please include them in the next release?