### PR TITLE
Fix style

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.6"
-pydantic = ">=0.32.2<2.0.0"
-hypothesis = ">=4.36<6.0.0"
+pydantic = ">=0.32.2, <2.0.0"
+hypothesis = ">=4.36, <6.0.0"
 pytest = { version = "^4.0.0", optional = true }
 
 [tool.poetry.extras]


### PR DESCRIPTION
Fixes 

```bash
[...]
, line 33, in parse_constraint
      constraint_objects.append(parse_single_constraint(and_constraints[0]))
    File "/nix/store/vx9yygl10jp63pvh4nlxgvkzvxkb7yl6-python3.10-poetry-core-1.3.2/lib/python3.10/site-packages/poetry/core/constraints/version/parser.py", line 147, in parse_single_constraint
      raise ParseConstraintError(f"Could not parse version constraint: {constraint}")
  poetry.core.constraints.version.exceptions.ParseConstraintError: Could not parse version constraint: >=0.32.2<2.0.0
  error: subprocess-exited-with-error
[...]
```