### PR TITLE
Bump upper hypothesis pin to fix "AttributeError: 'EntryPoints' object has no attribute 'get'"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ include = [
 [tool.poetry.dependencies]
 python = ">=3.6"
 pydantic = ">=0.32.2, <2.0.0"
-hypothesis = ">=4.36, <6.0.0"
+hypothesis = ">=4.36, <7.0.0"
 pytest = { version = ">=4.0.0", optional = true }
 
 [tool.poetry.extras]


### PR DESCRIPTION
Hypothesis 6.0.0 came out on Jan 9, 2021:
* https://github.com/HypothesisWorks/hypothesis/releases/tag/hypothesis-python-6.0.0

They're now up to 6.65.2:
* https://github.com/HypothesisWorks/hypothesis/releases/tag/hypothesis-python-6.65.2

I'm getting the following failure for Python 3.7 and 3.12-dev with hypothesis-auto==1.1.5, which uses hypothesis==5.49.0. It passes for 3.8-3.11.

```pytb
py: commands[0]> .tox/py/bin/python -m pytest --cov tinytext --cov tests --cov-report xml
Traceback (most recent call last):
  File "/Users/runner/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/Users/runner/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/runner/work/tinytext/tinytext/.tox/py/lib/python3.7/site-packages/pytest/__main__.py", line 5, in <module>
    raise SystemExit(pytest.console_main())
  File "/Users/runner/work/tinytext/tinytext/.tox/py/lib/python3.7/site-packages/_pytest/config/__init__.py", line 190, in console_main
    code = main()
  File "/Users/runner/work/tinytext/tinytext/.tox/py/lib/python3.7/site-packages/_pytest/config/__init__.py", line 148, in main
    config = _prepareconfig(args, plugins)
  File "/Users/runner/work/tinytext/tinytext/.tox/py/lib/python3.7/site-packages/_pytest/config/__init__.py", line 330, in _prepareconfig
    pluginmanager=pluginmanager, args=args
  File "/Users/runner/work/tinytext/tinytext/.tox/py/lib/python3.7/site-packages/pluggy/_hooks.py", line 265, in __call__
    return self._hookexec(self.name, self.get_hookimpls(), kwargs, firstresult)
  File "/Users/runner/work/tinytext/tinytext/.tox/py/lib/python3.7/site-packages/pluggy/_manager.py", line 80, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/Users/runner/work/tinytext/tinytext/.tox/py/lib/python3.7/site-packages/pluggy/_callers.py", line 55, in _multicall
    gen.send(outcome)
  File "/Users/runner/work/tinytext/tinytext/.tox/py/lib/python3.7/site-packages/_pytest/helpconfig.py", line 103, in pytest_cmdline_parse
    config: Config = outcome.get_result()
  File "/Users/runner/work/tinytext/tinytext/.tox/py/lib/python3.7/site-packages/pluggy/_result.py", line 60, in get_result
    raise ex[1].with_traceback(ex[2])
  File "/Users/runner/work/tinytext/tinytext/.tox/py/lib/python3.7/site-packages/pluggy/_callers.py", line 39, in _multicall
    res = hook_impl.function(*args)
  File "/Users/runner/work/tinytext/tinytext/.tox/py/lib/python3.7/site-packages/_pytest/config/__init__.py", line 10[58](https://github.com/hugovk/tinytext/actions/runs/4061829200/jobs/6992224202#step:5:59), in pytest_cmdline_parse
    self.parse(args)
  File "/Users/runner/work/tinytext/tinytext/.tox/py/lib/python3.7/site-packages/_pytest/config/__init__.py", line 1346, in parse
    self._preparse(args, addopts=addopts)
  File "/Users/runner/work/tinytext/tinytext/.tox/py/lib/python3.7/site-packages/_pytest/config/__init__.py", line 1229, in _preparse
    self.pluginmanager.load_setuptools_entrypoints("pytest11")
  File "/Users/runner/work/tinytext/tinytext/.tox/py/lib/python3.7/site-packages/pluggy/_manager.py", line 287, in load_setuptools_entrypoints
    plugin = ep.load()
  File "/Users/runner/work/tinytext/tinytext/.tox/py/lib/python3.7/site-packages/importlib_metadata/__init__.py", line 208, in load
    module = import_module(match.group('module'))
  File "/Users/runner/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 953, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 953, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "/Users/runner/work/tinytext/tinytext/.tox/py/lib/python3.7/site-packages/_pytest/assertion/rewrite.py", line 168, in exec_module
    exec(co, module.__dict__)
  File "/Users/runner/work/tinytext/tinytext/.tox/py/lib/python3.7/site-packages/hypothesis/__init__.py", line [61](https://github.com/hugovk/tinytext/actions/runs/4061829200/jobs/6992224202#step:5:62), in <module>
    run()
  File "/Users/runner/work/tinytext/tinytext/.tox/py/lib/python3.7/site-packages/hypothesis/entry_points.py", line 61, in run
    for entry in get_entry_points():  # pragma: no cover
  File "/Users/runner/work/tinytext/tinytext/.tox/py/lib/python3.7/site-packages/hypothesis/entry_points.py", line 32, in get_entry_points
    yield from importlib_metadata.entry_points().get("hypothesis", [])
AttributeError: 'EntryPoints' object has no attribute 'get'
py: exit 1 (1.30 seconds) /Users/runner/work/tinytext/tinytext> .tox/py/bin/python -m pytest --cov tinytext --cov tests --cov-report xml pid=2006
```

https://github.com/hugovk/tinytext/actions/runs/4061829200

This looks like https://github.com/HypothesisWorks/hypothesis/issues/3473 which is already fixed in Hypothesis.

If I `pip install -U hypothesis` right after installing `hypothesis-auto`, it works.

So let's bump the upper pin. Or can we remove it entirely?
